### PR TITLE
Listen to synchronize event

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,6 +23,7 @@ module.exports = robot => {
   robot.on('issues.reopened', update)
   robot.on('pull_request.reopened', update)
   robot.on('pull_request.closed', update)
+  robot.on('pull_request.synchronize', update)
 
   // Get an express router to expose new HTTP endpoints
   const app = robot.route('/')


### PR DESCRIPTION
Fixes #20 by listening to the `pull_request.synchronize` event which is done anytime there is a push.

I didn't test this out myself.